### PR TITLE
Remove Auth0 env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ streamlit run app/main.py
 The database schema can be initialized using the SQL in `sql/schema.sql`.
 
 Environment variables required:
-- `AUTH0_CLIENT_ID`
-- `AUTH0_DOMAIN`
 - `OPENAI_API_KEY`
 - `DATABASE_URL` (e.g. `postgresql://user:pass@localhost:5432/dbname`)
+
+Auth0 credentials must be provided in `st.secrets` under an `auth0` section:
+
+```toml
+[auth0]
+client_id = "..."
+domain = "..."
+```

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,9 +1,12 @@
-import os
 import streamlit as st
 from auth0_component import login_button
 
-AUTH0_CLIENT_ID = os.getenv("AUTH0_CLIENT_ID")
-AUTH0_DOMAIN = os.getenv("AUTH0_DOMAIN")
+AUTH0_CLIENT_ID = None
+AUTH0_DOMAIN = None
+
+if "auth0" in st.secrets:
+    AUTH0_CLIENT_ID = st.secrets["auth0"].get("client_id")
+    AUTH0_DOMAIN = st.secrets["auth0"].get("domain")
 
 
 def authenticate():


### PR DESCRIPTION
## Summary
- remove environment variable lookup for Auth0 credentials
- clarify in README that Auth0 settings belong in `st.secrets`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688231332370832097fb64ec4da2d143