### PR TITLE
Improve Auth0 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,20 @@ Auth0 credentials must be provided in `st.secrets` under an `auth0` section:
 client_id = "..."
 domain = "..."
 ```
+
+### Auth0 setup
+
+When configuring the Auth0 application, ensure the Streamlit component's
+callback URL is whitelisted. Add the following URL to **Allowed Callback URLs**
+in your Auth0 application settings:
+
+```
+https://<your-domain>/~/+/component/auth0_component.login_button/index.html
+```
+
+Replace `<your-domain>` with the host where the app runs. For example, when
+deployed to Streamlit Community Cloud the URL may look like
+`https://capture.streamlit.app/~/+/component/auth0_component.login_button/index.html`.
+
+Without this URL in the allow list, login attempts will fail with a "Callback
+URL mismatch" error.


### PR DESCRIPTION
## Summary
- document the callback URL that must be added in Auth0

## Testing
- `python -m py_compile app/*.py`
- `python -m compileall app`

------
https://chatgpt.com/codex/tasks/task_e_68823fc015948320929c38727ebda169