### PR TITLE
Clarify OpenAI API key setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ streamlit run app/main.py
 The database schema can be initialized using the SQL in `sql/schema.sql`.
 
 Environment variables required:
-- `OPENAI_API_KEY`
+- `OPENAI_API_KEY` or `BOOF_API_KEY`
 - `DATABASE_URL` (e.g. `postgresql://user:pass@localhost:5432/dbname`)
+
+The app will also look for `openai_api_key` in `st.secrets` when running on
+Streamlit Cloud.
 

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,11 @@ import pytesseract
 # Initialize the OpenAI client using the BOOF_API_KEY environment variable
 # if available. Fallback to the standard OPENAI_API_KEY so the application
 # remains compatible with setups that already use that name.
-API_KEY = os.getenv("BOOF_API_KEY") or os.getenv("OPENAI_API_KEY")
+API_KEY = (
+    os.getenv("BOOF_API_KEY")
+    or os.getenv("OPENAI_API_KEY")
+    or st.secrets.get("openai_api_key")
+)
 client = OpenAI(api_key=API_KEY) if API_KEY else None
 DB_URL = os.getenv("DATABASE_URL")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit
-openai
+openai>=1.0
 psycopg2-binary
 pytesseract
 Pillow


### PR DESCRIPTION
## Summary
- read OpenAI key from `st.secrets`
- document how to configure the API key
- require modern `openai` library

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6882479af9388320abe64ffbd2d9284d