### PR TITLE
Remove env var lookup for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ streamlit run app/main.py
 The database schema can be initialized using the SQL in `sql/schema.sql`.
 
 Environment variables required:
-- `OPENAI_API_KEY` or `BOOF_API_KEY`
 - `DATABASE_URL` (e.g. `postgresql://user:pass@localhost:5432/dbname`)
 
-The app will also look for `openai_api_key` in `st.secrets` when running on
-Streamlit Cloud.
+The OpenAI API key must be stored in `st.secrets` as `BOOF_API_KEY` under the
+`[database]` section. No environment variable lookup is performed.
 

--- a/app/main.py
+++ b/app/main.py
@@ -7,15 +7,9 @@ import psycopg2
 from openai import OpenAI
 from PIL import Image
 import pytesseract
-# Initialize the OpenAI client using the BOOF_API_KEY environment variable
-# if available. Fallback to the standard OPENAI_API_KEY so the application
-# remains compatible with setups that already use that name.
-API_KEY = (
-    os.getenv("BOOF_API_KEY")
-    or os.getenv("OPENAI_API_KEY")
-    or st.secrets.get("openai_api_key")
-)
-client = OpenAI(api_key=API_KEY) if API_KEY else None
+
+BOOF_API_KEY = st.secrets["database"]["BOOF_API_KEY"]
+client = OpenAI(api_key=BOOF_API_KEY)
 DB_URL = os.getenv("DATABASE_URL")
 
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -82,10 +76,6 @@ def ocr_image(image_bytes):
 def gpt_vision(image_bytes, prompt, model="gpt-4o"):
     """Query the OpenAI vision model with ``image_bytes`` and ``prompt``."""
 
-    if client is None:
-        logger.warning("OpenAI client not configured")
-        return ""
-
     b64 = base64.b64encode(image_bytes).decode()
     messages = [
         {
@@ -106,9 +96,6 @@ def main():
     logger.info("Starting Capture Application")
     st.title("Capture Application")
 
-    if client is None:
-        st.error("OpenAI API key not configured")
-        st.stop()
 
     user_id = "anon"
     logger.info("User ID: %s", user_id)


### PR DESCRIPTION
## Summary
- drop environment variable fallbacks for the OpenAI API key
- update README to describe secrets-only configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688248d78ed88320908a266d341f6e64