### PR TITLE
Add GPT fallback for OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
-The OCR functionality requires the Tesseract engine. On Ubuntu install it with:
+The OCR functionality uses the Tesseract engine if available.
+On Ubuntu install it with:
 
 ```bash
 sudo apt-get install tesseract-ocr
 ```
 
 On Windows download it from [https://github.com/tesseract-ocr/tesseract](https://github.com/tesseract-ocr/tesseract) and set the `TESSERACT_CMD` environment variable to the installed binary path if it's not in your `PATH`.
+
+If you are deploying to an environment where system packages cannot be installed (e.g. Streamlit Community Cloud), include a PyPI package that bundles Tesseract in your `requirements.txt` or rely on the GPT Vision fallback built into the app. When Tesseract is placed in a custom location, set the `TESSERACT_CMD` variable so `pytesseract` can find it.
 
 Run the app locally:
 ```bash

--- a/app/main.py
+++ b/app/main.py
@@ -97,11 +97,12 @@ def ocr_image(image_bytes):
     try:
         return pytesseract.image_to_string(image)
     except pytesseract.TesseractNotFoundError:
-        logger.exception("Tesseract executable not found")
-        st.error(
-            "Tesseract OCR is not installed or not found. Set the TESSERACT_CMD environment variable if needed."
+        logger.warning("Tesseract executable not found, falling back to GPT Vision")
+        st.warning(
+            "Tesseract OCR is not available. Falling back to GPT Vision for text extraction."
         )
-        return ""
+        # Use the vision model to extract text from the image
+        return gpt_vision(image_bytes, "Extract the text from this image as plain text")
 
 
 def gpt_vision(image_bytes, prompt, model="gpt-4o"):


### PR DESCRIPTION
## Summary
- use GPT Vision as a fallback when Tesseract is unavailable
- clarify in README how to handle Tesseract on Streamlit Community Cloud

## Testing
- `python -m py_compile app/main.py app/api.py`

------
https://chatgpt.com/codex/tasks/task_e_688259d114fc8320a6ed772aca84547d