### PR TITLE
Add Mistral OCR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Streamlit application for capturing images and extracting actionable knowledge
 
 ## Features
 - **Image Capture**: Use camera input to take pictures of whiteboards, notebooks or any other source.
-- **OCR & GPT Vision**: Extract text from handwriting and typed content. Convert diagrams to Markdown.
+- **Mistral OCR & GPT Vision**: Extract text from handwriting and typed content. Convert diagrams to Markdown.
 - **Summaries & Next Actions**: Summarize the captured content and suggest next steps.
 - **PostgreSQL Storage**: All data is stored in a dedicated schema.
 
@@ -15,8 +15,9 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
-The OCR functionality uses the Tesseract engine if available.
-On Ubuntu install it with:
+The OCR functionality uses the Mistral service when a `MISTRAL_API_KEY` is provided.
+If Mistral is not configured the app falls back to the Tesseract engine when available.
+On Ubuntu install Tesseract with:
 
 ```bash
 sudo apt-get install tesseract-ocr
@@ -24,7 +25,7 @@ sudo apt-get install tesseract-ocr
 
 On Windows download it from [https://github.com/tesseract-ocr/tesseract](https://github.com/tesseract-ocr/tesseract) and set the `TESSERACT_CMD` environment variable to the installed binary path if it's not in your `PATH`.
 
-If you are deploying to an environment where system packages cannot be installed (e.g. Streamlit Community Cloud), include a PyPI package that bundles Tesseract in your `requirements.txt` or rely on the GPT Vision fallback built into the app. When Tesseract is placed in a custom location, set the `TESSERACT_CMD` variable so `pytesseract` can find it.
+If you are deploying to an environment where system packages cannot be installed (e.g. Streamlit Community Cloud), rely on the Mistral OCR service or the GPT Vision fallback built into the app. When Tesseract is placed in a custom location, set the `TESSERACT_CMD` variable so `pytesseract` can find it.
 
 Run the app locally:
 ```bash
@@ -38,7 +39,8 @@ The database schema can be initialized using the SQL in `sql/schema.sql`.
 Configuration values are loaded exclusively from `st.secrets`.
 Provide the database credentials under the `[database]` section using
 `AIVEN_HOST`, `AIVEN_PORT`, `AIVEN_DB`, `AIVEN_USER`, and `AIVEN_PASSWORD`.
-Store the OpenAI key as `BOOF_API_KEY` in the same section. No environment
+Store the OpenAI key as `BOOF_API_KEY` in the same section and optionally
+include `MISTRAL_API_KEY` for the Mistral OCR service. No environment
 variable lookup is performed by the app.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ openai>=1.0
 psycopg2-binary
 pytesseract
 Pillow
+requests
 
 fastapi
 uvicorn


### PR DESCRIPTION
## Summary
- integrate Mistral OCR service for text extraction
- update documentation for Mistral
- add requests dependency

## Testing
- `python -m py_compile app/main.py app/api.py`
- `pytest -q`
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit)*

------
https://chatgpt.com/codex/tasks/task_e_68825b52074c8320a2c43474e125d681