### PR TITLE
Improve Mistral OCR error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ via the environment variables `AIVEN_HOST`, `AIVEN_PORT`, `AIVEN_DB`,
 
 ## Troubleshooting
 
-If the app displays the message `Mistral OCR unavailable. Using GPT Vision only
-for text extraction.` it means the Mistral service failed or is not configured.
-Provide a valid `MISTRAL_API_KEY` in `st.secrets` to enable the dedicated OCR
-service. Check the terminal output for log messages starting with
-`Mistral OCR failed` or `Mistral OCR not configured` to determine
-whether the API key is missing or the remote service is unreachable.
+If the app displays a message beginning with `Mistral OCR unavailable` it means
+the Mistral service failed or is not configured. The warning now includes the
+underlying error when available. Provide a valid `MISTRAL_API_KEY` in
+`st.secrets` to enable the dedicated OCR service. Check the terminal output for
+log messages starting with `Mistral OCR failed` or `Mistral OCR not configured`
+to determine whether the API key is missing or the remote service is
+unreachable.

--- a/app/main.py
+++ b/app/main.py
@@ -115,18 +115,24 @@ def ocr_image(image_bytes):
     logger.debug("Running OCR on captured image")
 
     text_mistral = ""
+    error_msg = ""
     if MISTRAL_API_KEY:
         try:
             text_mistral = mistral_ocr(image_bytes).strip()
         except Exception as exc:
+            error_msg = str(exc)
             logger.warning("Mistral OCR failed: %s", exc)
     else:
+        error_msg = "MISTRAL_API_KEY missing"
         logger.warning("Mistral OCR not configured")
 
     if not text_mistral:
-        st.warning(
-            "Mistral OCR unavailable. Using GPT Vision only for text extraction."
-        )
+        msg = "Mistral OCR unavailable. Using GPT Vision only for text extraction."
+        if error_msg:
+            msg = (
+                f"Mistral OCR unavailable ({error_msg}). Using GPT Vision only for text extraction."
+            )
+        st.warning(msg)
 
     text_gpt = gpt_vision(
         image_bytes, "Extract the text from this image as plain text"


### PR DESCRIPTION
## Summary
- show the underlying Mistral OCR error in the UI
- document the improved message in the troubleshooting guide

## Testing
- `python -m py_compile app/main.py app/api.py`

------
https://chatgpt.com/codex/tasks/task_e_6882915ada788320933ddb72e187f471