### PR TITLE
Ensure rear camera opens by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A Streamlit application for capturing images and extracting actionable knowledge using OpenAI vision models.
 
 ## Features
-- **Image Capture**: Use camera input to take pictures of whiteboards, notebooks or any other source.
+- **Image Capture**: Use camera input to take pictures of whiteboards, notebooks or any other source. The app
+  defaults to the device's back camera so you don't start in selfie mode.
 - **Mistral OCR & GPT Vision**: Combine both services to extract text and convert diagrams to Markdown.
 - **Summaries & Next Actions**: Summarize the captured content and suggest next steps.
 - **PostgreSQL Storage**: All data is stored in a dedicated schema.

--- a/app/main.py
+++ b/app/main.py
@@ -178,7 +178,11 @@ def main():
     logger.info("User ID: %s", user_id)
     conn = connect_db()
 
-    picture = st.camera_input("Take a picture")
+    try:
+        picture = st.camera_input("Take a picture", facing_mode="environment")
+    except TypeError:
+        # ``facing_mode`` not supported in older Streamlit versions
+        picture = st.camera_input("Take a picture")
     if not picture:
         picture = st.file_uploader("Or upload an image", type=["png", "jpg", "jpeg"])
 


### PR DESCRIPTION
## Summary
- default to the device's back camera in the Streamlit app
- document the new behaviour in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688360b0861c8320ae3198d8827e9d6b