### PR TITLE
Add helper for back camera capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 A Streamlit application for capturing images and extracting actionable knowledge using OpenAI vision models.
 
 ## Features
-- **Image Capture**: Use camera input to take pictures of whiteboards, notebooks or any other source. The app
-  defaults to the device's back camera so you don't start in selfie mode.
+- **Image Capture**: Use the `back_camera_input()` helper to take pictures of
+  whiteboards, notebooks or any other source. The app tries to use the device's
+  back camera and falls back to the default camera when the option isn't
+  supported.
 - **Mistral OCR & GPT Vision**: Combine both services to extract text and convert diagrams to Markdown.
 - **Summaries & Next Actions**: Summarize the captured content and suggest next steps.
 - **PostgreSQL Storage**: All data is stored in a dedicated schema.
@@ -26,6 +28,10 @@ streamlit run app/main.py
 ```
 
 If the browser does not prompt for camera access you can upload an image instead when running the app. Make sure to open `http://localhost:8501` in a browser that allows camera permissions.
+
+The `back_camera_input()` helper wraps `st.camera_input` and automatically
+requests the back camera when supported. It gracefully falls back to the default
+camera on older Streamlit versions.
 
 The database schema can be initialized using the SQL in `sql/schema.sql`.
 

--- a/app/back_camera_input.py
+++ b/app/back_camera_input.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+
+def back_camera_input(label="Take a picture", **kwargs):
+    """Capture an image using the device's back camera when possible."""
+    try:
+        return st.camera_input(label, facing_mode="environment", **kwargs)
+    except TypeError:
+        # ``facing_mode`` not supported in older Streamlit versions
+        return st.camera_input(label, **kwargs)

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ import streamlit as st
 import psycopg2
 from openai import OpenAI
 import requests
+from app.back_camera_input import back_camera_input
 
 BOOF_API_KEY = st.secrets["database"]["BOOF_API_KEY"]
 client = OpenAI(api_key=BOOF_API_KEY)
@@ -178,11 +179,7 @@ def main():
     logger.info("User ID: %s", user_id)
     conn = connect_db()
 
-    try:
-        picture = st.camera_input("Take a picture", facing_mode="environment")
-    except TypeError:
-        # ``facing_mode`` not supported in older Streamlit versions
-        picture = st.camera_input("Take a picture")
+    picture = back_camera_input("Take a picture")
     if not picture:
         picture = st.file_uploader("Or upload an image", type=["png", "jpg", "jpeg"])
 


### PR DESCRIPTION
## Summary
- add `back_camera_input` utility to prefer the device's rear camera
- use the helper in `app/main.py`
- document new helper usage in README

## Testing
- `python -m py_compile app/main.py app/back_camera_input.py app/api.py`


------
https://chatgpt.com/codex/tasks/task_e_6883634312e48320aa12c0e8f0ef3caa