### PR TITLE
Remove camera toggle, default to rear camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A Streamlit application for capturing images and extracting actionable knowledge
 
 ## Features
 - **Image Capture**: Use the `back_camera_input()` helper to take pictures of
-  whiteboards, notebooks or any other source. The app tries to use the device's
-  back camera and falls back to the default camera when the option isn't
-  supported.
+  whiteboards, notebooks or any other source. The app defaults to the
+  device's back camera and falls back to the default camera when the
+  `facing_mode` option isn't supported.
 - **Mistral OCR & GPT Vision**: Combine both services to extract text and convert diagrams to Markdown.
 - **Summaries & Next Actions**: Summarize the captured content and suggest next steps.
 - **PostgreSQL Storage**: All data is stored in a dedicated schema.
@@ -30,8 +30,8 @@ streamlit run app/main.py
 If the browser does not prompt for camera access you can upload an image instead when running the app. Make sure to open `http://localhost:8501` in a browser that allows camera permissions.
 
 The `back_camera_input()` helper wraps `st.camera_input` and automatically
-requests the back camera when supported. It gracefully falls back to the default
-camera on older Streamlit versions.
+requests the back camera when supported. It gracefully falls back to the
+default camera if ``facing_mode`` is unsupported on older Streamlit versions.
 
 The database schema can be initialized using the SQL in `sql/schema.sql`.
 


### PR DESCRIPTION
## Summary
- default to back camera automatically via `back_camera_input`
- update docs to remove toggle explanation

## Testing
- `python -m py_compile app/back_camera_input.py app/main.py app/api.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit)*


------
https://chatgpt.com/codex/tasks/task_e_68836dc77ad4832092017bb67d53c41a