### PR TITLE
Improve messaging for missing Streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ via the environment variables `AIVEN_HOST`, `AIVEN_PORT`, `AIVEN_DB`,
 
 ## Troubleshooting
 
+If you encounter `ModuleNotFoundError` when starting the app, ensure all
+dependencies are installed:
+
+```bash
+pip install -r requirements.txt
+```
+
+The error typically appears when ``streamlit`` is missing from the Python
+environment.
+
 If the app displays a message beginning with `Mistral OCR unavailable` it means
 the Mistral service failed or is not configured. The warning now includes the
 underlying error when available. Provide a valid `MISTRAL_API_KEY` in

--- a/app/back_camera_input.py
+++ b/app/back_camera_input.py
@@ -1,4 +1,10 @@
-import streamlit as st
+try:
+    import streamlit as st
+except ModuleNotFoundError as exc:
+    raise ImportError(
+        "streamlit is required for the CAP app. "
+        "Install dependencies using `pip install -r requirements.txt`."
+    ) from exc
 
 
 def back_camera_input(label="Take a picture", **kwargs):

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,13 @@
 import io
 import base64
 import logging
-import streamlit as st
+try:
+    import streamlit as st
+except ModuleNotFoundError as exc:
+    raise ImportError(
+        "streamlit is required to run this app. "
+        "Install dependencies using `pip install -r requirements.txt`."
+    ) from exc
 import psycopg2
 from openai import OpenAI
 import requests


### PR DESCRIPTION
## Summary
- raise a clearer error if the Streamlit package isn't installed
- document how to resolve `ModuleNotFoundError` in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68837211277083208ccc5ce661161292