### PR TITLE
Fix module import failure on Streamlit Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,12 @@ via the environment variables `AIVEN_HOST`, `AIVEN_PORT`, `AIVEN_DB`,
 
 ## Troubleshooting
 
-If you encounter `ModuleNotFoundError` when starting the app, ensure all
-dependencies are installed:
-
-```bash
-pip install -r requirements.txt
-```
-
-The error typically appears when ``streamlit`` is missing from the Python
+If you encounter `ModuleNotFoundError` when starting the app, double-check that
+all dependencies listed in `requirements.txt` are installed. Streamlit
+Community Cloud automatically installs these packages when the app is deployed,
+so updating the file and re-deploying is usually sufficient. Locally you can
+run `pip install -r requirements.txt` to replicate the same environment. The
+error typically appears when ``streamlit`` is missing from the Python
 environment.
 
 If the app displays a message beginning with `Mistral OCR unavailable` it means

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""CAP application package."""


### PR DESCRIPTION
## Summary
- add `__init__.py` so `app` is treated as a package
- clarify troubleshooting instructions about dependency installation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68837758a7c88320b0a35da15c0fee40