### PR TITLE
Enable back camera capture using custom HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 A Streamlit application for capturing images and extracting actionable knowledge using OpenAI vision models.
 
 ## Features
-- **Image Capture**: Capture photos with Streamlit's built-in
-  `st.camera_input` widget. The widget automatically opens the device
-  camera and lets users upload an image when camera access isn't
-  available.
+- **Image Capture**: Capture photos with a custom HTML file input that
+  requests the device's back camera. The widget falls back to file
+  upload when camera access isn't available.
 - **Mistral OCR & GPT Vision**: Combine both services to extract text and convert diagrams to Markdown.
 - **Summaries & Next Actions**: Summarize the captured content and suggest next steps.
 - **PostgreSQL Storage**: All data is stored in a dedicated schema.
@@ -29,9 +28,9 @@ streamlit run app/main.py
 
 If the browser does not prompt for camera access you can upload an image
 instead when running the app. Make sure to open `http://localhost:8501` in
-a browser that allows camera permissions. The application relies on
-`st.camera_input` so older Streamlit versions without this widget are not
-supported.
+a browser that allows camera permissions. The app uses a plain HTML file
+input configured with `capture="environment"` to request the back camera
+on mobile devices.
 
 The database schema can be initialized using the SQL in `sql/schema.sql`.
 

--- a/app/html_camera_input.py
+++ b/app/html_camera_input.py
@@ -1,0 +1,22 @@
+try:
+    import streamlit as st
+except ModuleNotFoundError as exc:
+    raise ImportError(
+        "streamlit is required for the CAP app. "
+        "Install dependencies using `pip install -r requirements.txt`."
+    ) from exc
+
+
+def back_camera_uploader(label="Take a picture"):
+    """Use a file uploader that requests the back camera on mobile."""
+    uploader = st.file_uploader(label, type=["png", "jpg", "jpeg"], key="camera")
+    st.markdown(
+        """
+        <script>
+        const inputs = window.parent.document.querySelectorAll('input[type="file"]');
+        inputs.forEach(el => el.setAttribute('capture', 'environment'));
+        </script>
+        """,
+        unsafe_allow_html=True,
+    )
+    return uploader

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ except ModuleNotFoundError as exc:
 import psycopg2
 from openai import OpenAI
 import requests
+from app.html_camera_input import back_camera_uploader
 
 BOOF_API_KEY = st.secrets["database"]["BOOF_API_KEY"]
 client = OpenAI(api_key=BOOF_API_KEY)
@@ -184,9 +185,7 @@ def main():
     logger.info("User ID: %s", user_id)
     conn = connect_db()
 
-    picture = st.camera_input("Take a picture")
-    if not picture:
-        picture = st.file_uploader("Or upload an image", type=["png", "jpg", "jpeg"])
+    picture = back_camera_uploader("Take a picture")
 
     if picture:
         logger.info("Image captured")


### PR DESCRIPTION
## Summary
- add `back_camera_uploader` helper using a custom HTML file input
- use the helper in the main Streamlit app
- update README to describe new back camera uploader

## Testing
- `python -m py_compile app/*.py`
- `pip install -r requirements.txt` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68837d58062c8320b5d1d1bb8cb3b797