### PR TITLE
Fix back camera uploader import path

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,9 @@ except ModuleNotFoundError as exc:
 import psycopg2
 from openai import OpenAI
 import requests
-from app.html_camera_input import back_camera_uploader
+# Use a relative import so ``main.py`` works regardless of how the module is
+# executed (e.g. ``streamlit run app/main.py`` or ``python -m app.main``).
+from .html_camera_input import back_camera_uploader
 
 BOOF_API_KEY = st.secrets["database"]["BOOF_API_KEY"]
 client = OpenAI(api_key=BOOF_API_KEY)


### PR DESCRIPTION
## Summary
- avoid `ModuleNotFoundError` by importing `back_camera_uploader` using a
  relative import in `app/main.py`

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6883810c4ca48320af1b59a6adeca78f