### PR TITLE
Clean OCR text using GPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Streamlit application for capturing images and extracting actionable knowledge
 
 ## Features
 - **Image Capture**: Take a picture using Streamlit's camera widget with a fallback to file upload.
-- **Mistral OCR & GPT Vision**: Combine both services to extract text and convert diagrams to Markdown.
+- **Mistral OCR & GPT Vision**: Combine both services to extract text and convert diagrams to Markdown. The raw OCR is cleaned up by GPT before being saved.
 - **Summaries & Next Actions**: Summarize the captured content and suggest next steps.
 - **PostgreSQL Storage**: All data is stored in a dedicated schema.
 
@@ -17,7 +17,8 @@ pip install -r requirements.txt
 
 The app combines Mistral OCR with OpenAI's vision models. Provide a `MISTRAL_API_KEY`
 in `st.secrets` to enable the Mistral service. GPT Vision is always used alongside
-Mistral to refine the extracted text.
+Mistral to refine the extracted text. OCR output is cleaned by an additional GPT
+step before being stored.
 
 Run the app locally:
 ```bash

--- a/app/main.py
+++ b/app/main.py
@@ -153,8 +153,33 @@ def ocr_image(image_bytes):
     ).strip()
 
     if text_mistral and text_gpt and text_mistral != text_gpt:
-        return text_mistral + "\n" + text_gpt
-    return text_mistral or text_gpt
+        combined = text_mistral + "\n" + text_gpt
+    else:
+        combined = text_mistral or text_gpt
+
+    return refine_ocr_text(combined)
+
+
+def refine_ocr_text(text, model="gpt-4.1"):
+    """Use GPT to clean up and structure OCR text."""
+    if not text:
+        return text
+
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "Clean up the OCR output. Correct typical recognition errors and "
+                "format the result as structured plain text. Use bullet points "
+                "when appropriate."
+            ),
+        },
+        {"role": "user", "content": text},
+    ]
+
+    logger.debug("Refining OCR text with LLM")
+    resp = client.chat.completions.create(model=model, messages=messages)
+    return resp.choices[0].message.content.strip()
 
 
 def gpt_vision(image_bytes, prompt, model="gpt-4.1"):


### PR DESCRIPTION
## Summary
- refine OCR output with GPT before storing
- update README with details about OCR cleanup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883d3e0114883208d0d8c3988e781ac